### PR TITLE
Add table width arg

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -32,3 +32,8 @@ Change log
 * Fix bug when calls to the same file multiple times chunks the table together
 * Fix bug date NameError when running in Python 3
 * Use the new merged_cells interface of openpyxl
+
+1.0.7
+-----
+
+* Adds the ability to set the table width

--- a/README.rst
+++ b/README.rst
@@ -126,6 +126,17 @@ scrollbar in case where parent's width is narrower then table's width. The defau
        :file: path/to/file.xlsx
        :overflow: false
 
+**width (optional)**
+
+Defines spreadsheet width in pixels. Accepts number, string (that will be converted to a number). The underlying
+spreadsheet implementation defaults to a width of 600px, you can change the value here if needed.
+
+.. code-block::
+
+    .. excel-table::
+       :file: path/to/file.xlsx
+       :width: 1000
+
 **colwidths (optional)**
 
 Defines column widths in pixels. Accepts number, string (that will be converted to a number),

--- a/setup.py
+++ b/setup.py
@@ -4,9 +4,9 @@ import sys
 PY2 = sys.version_info[0] == 2
 PY26 = PY2 and sys.version_info[1] < 7
 
-NAME = 'sphinxcontrib-excel-table'
+NAME = 'sphinxcontrib-excel-table-enhanced'
 AUTHOR = 'Guangyu Suo'
-VERSION = '1.0.6'
+VERSION = '1.0.7'
 EMAIL = 'yugsuo@gmail.com'
 LICENSE = 'Apache License'
 DESCRIPTION = (

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import sys
 PY2 = sys.version_info[0] == 2
 PY26 = PY2 and sys.version_info[1] < 7
 
-NAME = 'sphinxcontrib-excel-table-enhanced'
+NAME = 'sphinxcontrib-excel-table'
 AUTHOR = 'Guangyu Suo'
 VERSION = '1.0.7'
 EMAIL = 'yugsuo@gmail.com'

--- a/sphinxcontrib/excel_table/excel_table.py
+++ b/sphinxcontrib/excel_table/excel_table.py
@@ -55,6 +55,7 @@ class ExcelTable(Directive):
         'rows': directives.unchanged,
         'selection': directives.unchanged,
         'overflow': directives.unchanged,
+        'tablewidth': directives.unchanged,
         'colwidths': directives.unchanged,
         'row_header': directives.unchanged,
         'col_header': directives.unchanged,
@@ -73,6 +74,7 @@ class ExcelTable(Directive):
         rows = self.options.get('rows')
         sheet_name = self.options.get('sheet')
         overflow = self.options.get('overflow', 'horizontal')
+        tablewidth = self.options.get('tablewidth', 'undefined')
         colwidths = self.options.get('colwidths', 'undefined')
         row_header = self.options.get('row_header', 'true')
         col_header = self.options.get('col_header', 'true')
@@ -99,6 +101,7 @@ class ExcelTable(Directive):
           'file_name': file_path,
           'sheet_name': sheet_name,
           'overflow': overflow,
+          'tablewidth': tablewidth,
           'colwidths': colwidths,
           'row_header': row_header,
           'col_header': col_header,

--- a/sphinxcontrib/excel_table/templates/table.html
+++ b/sphinxcontrib/excel_table/templates/table.html
@@ -5,6 +5,7 @@
     data: {{content}},
     preventOverflow: {{overflow}},
     readOnly: true,
+    width: {{tablewidth}},
     colWidths: {{colwidths}},
     manualColumnResize: true,
     manualRowResize: true,


### PR DESCRIPTION
Not sure if this change is in alignment with how you think things should work, but I ran into an issue where the display of the table (below the column headers), was limited to 600px as defined by Handsontable default size.  This change lets us configure the final result size.
