### PR TITLE
Add Sphinx Extension PyPi classifier

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ CLASSIFIERS = [
     'Topic :: Utilities',
     'Topic :: Software Development :: Libraries',
     'Programming Language :: Python',
+    'Framework :: Sphinx :: Extension',
     'Intended Audience :: Developers',
     'Programming Language :: Python :: 2.6',
     'Programming Language :: Python :: 2.7',


### PR DESCRIPTION
Add the Sphinx Extension PyPi classifier so that the extension shows up in the correct [PyPi filters](https://pypi.org/search/?c=Framework+%3A%3A+Sphinx+%3A%3A+Extension).